### PR TITLE
Reply() functionality without text encoding issue handling

### DIFF
--- a/browser/imap.py
+++ b/browser/imap.py
@@ -34,16 +34,7 @@ def authenticate(imap_account):
             # TODO if access_token is expired, then get a new token
             imap_client.oauth2_login(imap_account.email, imap_account.access_token)
         else:
-            aes = AES.new(IMAP_SECRET, AES.MODE_CBC, 'This is an IV456')
-            password = aes.decrypt( base64.b64decode(imap_account.password) )
-            index = 0
-            last_string = password[-1]
-            for c in reversed(password):
-                if last_string != c:
-                    password = password[:(-1)*index]
-                    break
-                index = index + 1
-
+            password = decrypt_plain_password(imap_account.password)
             imap_client.login(imap_account.email, password)
 
         res['imap'] = imap_client
@@ -93,3 +84,16 @@ def authenticate(imap_account):
         imap_account.save()
 
     return res
+
+def decrypt_plain_password(encrypted_password):
+    aes = AES.new(IMAP_SECRET, AES.MODE_CBC, 'This is an IV456')
+    password = aes.decrypt( base64.b64decode(encrypted_password) )
+    index = 0
+    last_string = password[-1]
+    for c in reversed(password):
+        if last_string != c:
+            password = password[:(-1)*index]
+            break
+        index = index + 1
+
+    return password

--- a/engine/google_auth.py
+++ b/engine/google_auth.py
@@ -39,8 +39,7 @@ class GoogleOauth2():
   TOKEN_EXPIRED_TIME = None
 
   def __init__(self):
-    print "OAUTH", CLIENT_ID, CLIENT_SECRET
-    #pass
+    pass
 
   def isExpired(self): 
     if not self.TOKEN_EXPIRED_TIME:
@@ -62,6 +61,12 @@ class GoogleOauth2():
     logger.debug('Refresh Access Token Expiration Seconds: %s' % response['expires_in'])
 
     return response
+
+  def generate_oauth2_string(self, username, access_token, as_base64=False):
+    auth_string = 'user=%s\1auth=Bearer %s\1\1' % (username, access_token)
+    if as_base64:
+        auth_string = base64.b64encode(auth_string.encode('ascii')).decode('ascii')
+    return auth_string  
     
   def generate_oauth2_token(self, authorization_code):
     response = self.AuthorizeTokens(CLIENT_ID, CLIENT_SECRET,

--- a/engine/models/mailbox.py
+++ b/engine/models/mailbox.py
@@ -7,7 +7,7 @@ import typing as t  # noqa: F401 ignore unused we use it for typing
 from schema.youps import ImapAccount, FolderSchema, MailbotMode, EmailRule  # noqa: F401 ignore unused we use it for typing
 from folder import Folder
 from engine.models.contact import Contact
-from smtp_handler.utils import send_email
+from smtp_handler.utils import format_email_address, send_email
 from email import message
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
@@ -190,53 +190,14 @@ class MailBox(object):
         new_message = MIMEMultipart('alternative')
         new_message["Subject"] = subject
         
-        if isinstance(to, list):
-            to_string = []
-            for t in to:
-                if isinstance(t, Contact):
-                    to_string.append(t.email)
-                else:
-                    to_string.append(t)
-
-            to = ",".join(to_string)
-        else:
-            if isinstance(to, Contact):
-                to = to.email 
-
-        if isinstance(cc, list):
-            cc_string = []
-            
-            for c in cc:
-                if isinstance(c, Contact):
-                    logger.info(c.email)
-                    cc_string.append(c.email)
-                else:
-                    cc_string.append(c)
-
-            cc = ",".join(cc_string)
-        else:
-            if isinstance(cc, Contact):
-                cc = cc.email 
-
-        if isinstance(bcc, list):
-            bcc_string = []
-            for t in bcc:
-                if isinstance(t, Contact):
-                    bcc_string.append(t.email)
-                else:
-                    bcc_string.append(t)
-
-            bcc = ",".join(bcc_string)
-        else:
-            if isinstance(bcc, Contact):
-                bcc = bcc.email
+        to = format_email_address(to)
+        cc = format_email_address(cc)
+        bcc = format_email_address(bcc)
          
         new_message["To"] = to
         new_message["Cc"] = cc
         new_message["Bcc"] = bcc
-        logger.info(to)
-        logger.info(cc)
-        logger.info(bcc)
+        
         # new_message.set_payload(content.encode('utf-8')) 
         if "text" in content and "html" in content:
             part1 = MIMEText(content["text"].encode('utf-8'), 'plain')

--- a/engine/models/message.py
+++ b/engine/models/message.py
@@ -541,8 +541,11 @@ class Message(object):
 
             content = self.content
             separator = "On %s, (%s) wrote:" % (datetime.now().ctime(), self._schema.imap_account.email)
-            part1 = MIMEText(additional_content + "\n\n" + separator + "\n\n" + content["text"].encode('utf-8'), 'plain')
-            part2 = MIMEText(additional_content + "<br><br>" + separator + "<br><br>" + content["html"].encode('utf-8'), 'html')
+            text_content = additional_content + "\n\n" + separator + "\n\n" + content["text"]
+            html_content = additional_content + "<br><br>" + separator + "<br><br>" + content["html"]
+
+            part1 = MIMEText(text_content.encode('utf-8'), 'plain')
+            part2 = MIMEText(html_content.encode('utf-8'), 'html')
             new_message.attach(part1)
             new_message.attach(part2)
 
@@ -555,7 +558,6 @@ class Message(object):
             attachments = res['attachments']
 
             for attachment in attachments:
-                # mail = setup_post("sbhappylee@gmail.com", "test")
                 p = MIMEBase('application', 'octet-stream') 
     
                 # To change the payload into encoded form 
@@ -565,8 +567,7 @@ class Message(object):
                 encoders.encode_base64(p) 
                 
                 p.add_header('Content-Disposition', "attachment; filename= %s" % attachment['filename']) 
-                new_message_wrapper.attach(p) 
-            # add_attachments(mail, attachments)
+                new_message_wrapper.attach(p)
 
             new_message_wrapper.attach(new_message)
         except Exception as e:

--- a/engine/models/message.py
+++ b/engine/models/message.py
@@ -7,7 +7,18 @@ from engine.models.contact import Contact
 import logging
 from collections import Sequence
 import email
-import inspect 
+import inspect
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from email.mime.base import MIMEBase 
+from email import encoders  
+from smtp_handler.utils import add_attachments, get_attachments, setup_post 
+import smtplib
+
+from engine.google_auth import GoogleOauth2
+from browser.imap import decrypt_plain_password
+
+from http_handler.settings import CLIENT_ID
 
 userLogger = logging.getLogger('youps.user')  # type: logging.Logger
 logger = logging.getLogger('youps')  # type: logging.Logger
@@ -66,6 +77,11 @@ class Message(object):
         # type: (int) -> None
         self._schema.msn = value
         self._schema.save()
+
+    @property
+    def _message_id(self):
+        # type: () -> int
+        return self._schema.message_id
 
     @property
     def flags(self):
@@ -428,6 +444,136 @@ class Message(object):
         if not self._is_message_already_in_dst_folder(dst_folder):
             if not self.is_simulate:
                 self._imap_client.move(self._uid, dst_folder)
+
+    def reply(self, to=[], cc=[], bcc=[], content=""):
+        # type: (t.Iterable[t.AnyStr], t.Iterable[t.AnyStr], t.Iterable[t.AnyStr], t.AnyStr) -> None
+        """Reply to the sender of this message
+        """
+        if not self.is_simulate:
+            new_message_wrapper = MIMEMultipart('mixed')
+            new_message_wrapper["Subject"] = "Re: " + self.subject
+            new_message_wrapper["To"] = to
+            new_message_wrapper["Cc"] = cc
+            new_message_wrapper["Bcc"] = bcc
+
+            new_message_wrapper['In-Reply-To'] = self._message_id
+            new_message_wrapper['References'] = self._message_id
+
+            # check if the message is initially read
+            initially_unread = self.is_read
+            try:
+
+                # fetch the data its a dictionary from uid to data so extract the data 
+                response = self._imap_client.fetch(
+                    self._uid, ['RFC822'])  # type: t.Dict[t.AnyStr, t.Any]
+                if self._uid not in response:
+                    raise RuntimeError('Invalid response missing UID')
+                response = response[self._uid]
+
+                if 'RFC822' not in response:
+                    logger.critical('%s:%s response: %s' % (self.folder, self, pprint.pformat(response)))
+                    logger.critical("%s did not return RFC822" % self)
+                    raise RuntimeError("Could not find RFC822")
+
+                # text content
+                new_message = MIMEMultipart('alternative')   
+
+                content = self.content
+                separator = "On %s, (%s) wrote:" % (datetime.now().ctime(), self._schema.imap_account.email)
+                part1 = MIMEText(separator + "\n\n" + content["text"].encode('utf-8'), 'plain')
+                part2 = MIMEText(separator + "<br><br>" + content["html"].encode('utf-8'), 'html')
+                new_message.attach(part1)
+                new_message.attach(part2)
+
+                # get attachments
+                rfc_contents = email.message_from_string(
+                    response.get('RFC822'))  # type: email.message.Message
+
+                res = get_attachments(rfc_contents)
+                    
+                attachments = res['attachments']
+
+                for attachment in attachments:
+                    # mail = setup_post("sbhappylee@gmail.com", "test")
+                    p = MIMEBase('application', 'octet-stream') 
+    
+                    # To change the payload into encoded form 
+                    p.set_payload(attachment['content']) 
+                    
+                    # encode into base64 
+                    encoders.encode_base64(p) 
+                    
+                    p.add_header('Content-Disposition', "attachment; filename= %s" % attachment['filename']) 
+                    new_message_wrapper.attach(p) 
+                # add_attachments(mail, attachments)
+
+            finally:
+                # mark the message unread if it is unread
+                if initially_unread:
+                    self.mark_read() 
+
+            new_message_wrapper.attach(new_message)
+
+            # SMTP authenticate 
+            if self._schema.imap_account.is_gmail:
+                oauth = GoogleOauth2()
+                response = oauth.RefreshToken(self._schema.imap_account.refresh_token)
+            
+                auth_string = oauth.generate_oauth2_string(self._schema.imap_account.email, response['access_token'], as_base64=True)
+                s = smtplib.SMTP('smtp.gmail.com', 587)
+                s.ehlo(CLIENT_ID)
+                s.starttls()
+                s.docmd('AUTH', 'XOAUTH2 ' + auth_string)
+                
+            else:
+                s = smtplib.SMTP(self._schema.imap_account.host.replace("imap", "smtp"), 587)
+                s.login(self._schema.imap_account.email, decrypt_plain_password(self._schema.imap_account.password))
+                s.ehlo()
+
+            s.sendmail(self._schema.imap_account.email, new_message_wrapper["To"], new_message_wrapper.as_string())
+
+            # TODO send mail 
+
+    
+
+    def _append_original_text(self, text, html, orig, google=False):
+        """
+        Append each part of the orig message into 2 new variables
+        (html and text) and return them. Also, remove any 
+        attachments. If google=True then the reply will be prefixed
+        with ">". The last is not tested with html messages...
+        """
+        newhtml = ""
+        newtext = ""
+
+        for part in orig.walk():
+            if (part.get('Content-Disposition')
+                and part.get('Content-Disposition').startswith("attachment")):
+
+                part.set_type("text/plain")
+                part.set_payload("Attachment removed: %s (%s, %d bytes)"
+                            %(part.get_filename(), 
+                            part.get_content_type(), 
+                            len(part.get_payload(decode=True))))
+                del part["Content-Disposition"]
+                del part["Content-Transfer-Encoding"]
+
+            if part.get_content_type().startswith("text/plain"):
+                newtext += "\n"
+                newtext += part.get_payload(decode=False)
+                if google:
+                    newtext = newtext.replace("\n","\n> ")
+
+            elif part.get_content_type().startswith("text/html"):
+                newhtml += "\n"
+                newhtml += part.get_payload(decode=True).decode("utf-8")
+                if google:
+                    newhtml = newhtml.replace("\n", "\n> ")
+
+        if newhtml == "":
+            newhtml = newtext.replace('\n', '<br/>')
+
+        return (text+'\n\n'+newtext, html+'<br/>'+newhtml)
 
     def _is_message_already_in_dst_folder(self, dst_folder):
         if dst_folder == self._schema.folder_schema.name:

--- a/http_handler/static/javascript/youps/login_imap.js
+++ b/http_handler/static/javascript/youps/login_imap.js
@@ -332,7 +332,7 @@ $(document).ready(function() {
             `<textarea class="editor mode-editor">{0}\n{1}</textarea>
         </div>
         <div class='debugger-container' mv-app='editor2' mv-storage='#mv-data-container'  class='mv-autoedit' mv-mode='edit'>
-            <button class='btn btn-default btn-debug-update'><i class="fas fa-sync"></i> Update results</button>
+            <button class='btn btn-default btn-debug-update'><i class="fas fa-sync"></i> Reload results</button>
             
             <h2>Test suites</h2>
             <h4>Recent messages from your selected folders to test your rules</h4>

--- a/smtp_handler/utils.py
+++ b/smtp_handler/utils.py
@@ -10,6 +10,7 @@ from email import message_from_string
 from hashlib import sha1
 from html2text import html2text
 from markdown2 import markdown
+from engine.models.contact import Contact
 import new, pickle, chardet
 
 '''
@@ -801,3 +802,25 @@ def utf8_str_to_utf8_unicode(encoded_str):
     """
 
     return unicode(encoded_str, 'utf8', 'replace')
+
+def format_email_address(email_addrs):
+    """Format a single instance or list to an approriate form to message instance e.g., user1@email.com, user2@email.com
+
+        Args:
+            email_addrs (a single instance|list of string|Contact)
+    """    
+
+    if isinstance(email_addrs, list):
+        to_string = []
+        for t in email_addrs:
+            if isinstance(t, Contact):
+                to_string.append(t.email)
+            else:
+                to_string.append(t)
+
+        email_addrs = ",".join(to_string)
+    else:
+        if isinstance(email_addrs, Contact):
+            email_addrs = email_addrs.email 
+
+    return email_addrs or ""


### PR DESCRIPTION
Part of #85. message.reply() implemented.

It sometimes crashes due to text encoding ( `'ascii' codec can't decode byte 0xc4 in position 2477: ordinal not in range(128)`) issue at here: https://github.com/soyapark/murmur/blob/ecc40f976817736046f58159fccc0cb1711777cb/engine/models/message.py#L483-L484

@lukesmurray Can you remind me how to use your text utility functions?
